### PR TITLE
Implement bulk DLQ delete

### DIFF
--- a/tests/asyncio/test_dlq.py
+++ b/tests/asyncio/test_dlq.py
@@ -46,3 +46,33 @@ async def test_dlq(client):
         filter(lambda msg: msg["messageId"] == msg_id, all_messages_after_delete)
     )
     assert len(msg_deleted) == 0
+
+@pytest.mark.asyncio
+async def test_dlq_delete_many(client):
+    print("Publishing 5 messages to a failed endpoint")
+    msg_ids = []
+    for _ in range(5):
+        pub_res = await client.publish_json({"url": "http://httpstat.us/404", "retries": 0})
+        msg_ids.append(pub_res["messageId"])
+    assert len(msg_ids) == 5
+  
+    print("Waiting 5 seconds for events to be delivered")
+    await asyncio.sleep(5)
+  
+    print("Checking if messages are in DLQ")
+    dlq = client.dlq()
+    all_messages = (await dlq.list_messages())["messages"]
+    msg_sent = list(filter(lambda msg: msg["messageId"] in msg_ids, all_messages))
+    assert len(msg_sent) == 5
+  
+    print("Deleting messages from DLQ")
+    dlq_ids = [msg["dlqId"] for msg in msg_sent]
+    await dlq.deleteMany({"dlq_ids": dlq_ids})
+
+    print("Checking if messages are deleted from DLQ")
+    all_messages_after_delete = (await dlq.list_messages())["messages"]
+    msg_deleted = list(
+        filter(lambda msg: msg["messageId"] in msg_ids, all_messages_after_delete)
+    )
+    assert len(msg_deleted) == 0
+    assert len(all_messages_after_delete) == len(all_messages) - 5

--- a/tests/test_dlq.py
+++ b/tests/test_dlq.py
@@ -43,3 +43,32 @@ def test_dlq(client):
         filter(lambda msg: msg["messageId"] == msg_id, all_messages_after_delete)
     )
     assert len(msg_deleted) == 0
+
+def test_dlq_delete_many(client):
+    print("Publishing 5 messages to a failed endpoint")
+    msg_ids = []
+    for _ in range(5):
+        pub_res = client.publish_json({"url": "http://httpstat.us/404", "retries": 0})
+        msg_ids.append(pub_res["messageId"])
+    assert len(msg_ids) == 5
+  
+    print("Waiting 5 seconds for events to be delivered")
+    time.sleep(5)
+  
+    print("Checking if messages are in DLQ")
+    dlq = client.dlq()
+    all_messages = dlq.list_messages()["messages"]
+    msg_sent = list(filter(lambda msg: msg["messageId"] in msg_ids, all_messages))
+    assert len(msg_sent) == 5
+  
+    print("Deleting messages from DLQ")
+    dlq_ids = [msg["dlqId"] for msg in msg_sent]
+    dlq.deleteMany({"dlq_ids": dlq_ids})
+
+    print("Checking if messages are deleted from DLQ")
+    all_messages_after_delete = dlq.list_messages()["messages"]
+    msg_deleted = list(
+        filter(lambda msg: msg["messageId"] in msg_ids, all_messages_after_delete)
+    )
+    assert len(msg_deleted) == 0
+    assert len(all_messages_after_delete) == len(all_messages) - 5

--- a/upstash_qstash/asyncio/dlq.py
+++ b/upstash_qstash/asyncio/dlq.py
@@ -1,7 +1,8 @@
 from typing import Optional
 from upstash_qstash.upstash_http import HttpClient
-from upstash_qstash.dlq import ListMessagesOpts, ListMessageResponse, DlqMessage
+from upstash_qstash.dlq import ListMessagesOpts, ListMessageResponse, DlqMessage, BulkDeleteRequest, BulkDeleteResponse
 from upstash_qstash.qstash_types import UpstashRequest
+import json
 
 
 class DLQ:
@@ -55,5 +56,18 @@ class DLQ:
                 "path": ["v2", "dlq", dlq_message_id],
                 "method": "DELETE",
                 "parse_response_as_json": False,
+            }
+        )
+
+    async def deleteMany(self, req: BulkDeleteRequest) -> BulkDeleteResponse:
+        """
+        Asynchronously remove many message from the DLQ
+        """
+        return await self.http.request_async(
+            {
+                "path": ["v2", "dlq"],
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"dlqIds": req.get('dlq_ids')}),
+                "method": "DELETE",
             }
         )

--- a/upstash_qstash/dlq.py
+++ b/upstash_qstash/dlq.py
@@ -1,6 +1,7 @@
 from typing import Optional, TypedDict, List, Dict
 from upstash_qstash.qstash_types import Method, UpstashRequest
 from upstash_qstash.upstash_http import HttpClient
+import json
 
 DlqMessage = TypedDict(
     "DlqMessage",
@@ -37,6 +38,21 @@ ListMessageResponse = TypedDict(
     {
         "messages": List[DlqMessage],
         "cursor": Optional[str],
+    },
+)
+
+
+BulkDeleteRequest = TypedDict(
+    "BulkDeleteRequest",
+    {
+        "dlq_ids": List[str],
+    },
+)
+
+BulkDeleteResponse = TypedDict(
+    "BulkDeleteResponse",
+    {
+        "deleted": int,
     },
 )
 
@@ -92,5 +108,18 @@ class DLQ:
                 "path": ["v2", "dlq", dlq_message_id],
                 "method": "DELETE",
                 "parse_response_as_json": False,
+            }
+        )
+
+    def deleteMany(self, req: BulkDeleteRequest) -> BulkDeleteResponse:
+        """
+        Remove many message from the DLQ
+        """
+        return self.http.request(
+            {
+                "path": ["v2", "dlq"],
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"dlqIds": req.get('dlq_ids')}),
+                "method": "DELETE",
             }
         )


### PR DESCRIPTION
Allow for users to delete many messages from the DLQ.

```py
dlq.deleteMany({
  dlq_ids: ["dlq_id_1", "dlq_id_2"]
})
```

```json
{
  "deleted": 2
}
```